### PR TITLE
Run example_pendulum_swingup

### DIFF
--- a/python/animate.py
+++ b/python/animate.py
@@ -36,7 +36,8 @@ def animate_pendulum(states,inputs,dt,parameters):
                                   interval=25, blit=True, init_func=init)
 
     # ani.save('pendulum_swingup.mp4', fps=15)
-    plt.show()
+    # plt.show()
+    return ani
 
 def animate_pendulum_tracking(states,states_new,inputs,dt,parameters):
     # Animation follows https://matplotlib.org/2.0.2/examples/animation/double_pendulum_animated.html

--- a/python/example_pendulum_swingup.py
+++ b/python/example_pendulum_swingup.py
@@ -47,5 +47,5 @@ ilqr_ = ilqr(init_state,target_state,initial_guess,dt,start_time,end_time,f,A,B,
 (states,inputs,k_feedforward,K_feedback,current_cost) = ilqr_.solve()
 
 # Animate
-animate_pendulum(states,inputs,dt,parameters)
+anim = animate_pendulum(states,inputs,dt,parameters)
 

--- a/python/symbolic_dynamics.py
+++ b/python/symbolic_dynamics.py
@@ -9,7 +9,7 @@ def symbolic_dynamics_pendulum():
     inputs = Matrix([u])
     states = Matrix([theta,theta_dot])
     # Defining the dynamics of the system
-    f = Matrix([theta_dot,(u-m*g*L*sp.sp.sin(theta))/(m*L*L)])
+    f = Matrix([theta_dot,(u-m*g*L*sp.sin(theta))/(m*L*L)])
 
     # Discretize the dynamics usp.sing euler integration
     f_disc = states+f*dt


### PR DESCRIPTION
Fix some bug and output animation for example_pendulum_swingup
This can be imported to colab by:

```
!git clone -l -s -b hcn-xkk-patch-1 https://github.com/hcn-xkk/ilqr-Kongx231.git cloned-repo2
%cd cloned-repo2
!ls
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.animation as animation
import time
import math

from matplotlib import rc
rc('animation', html='jshtml')
plt.rcParams["animation.html"] = "jshtml"

%matplotlib inline

%run /content/cloned-repo2/python/example_pendulum_swingup.py
anim
```